### PR TITLE
Use HTTPS for api call to EIA

### DIFF
--- a/process.ipynb
+++ b/process.ipynb
@@ -41,7 +41,7 @@
     "URLS = [\n",
     "    #'http://api.eia.gov/bulk/INTL.zip',\n",
     "    #'http://api.eia.gov/bulk/NUC_STATUS.zip',\n",
-    "    'http://api.eia.gov/bulk/PET.zip',\n",
+    "    'https://api.eia.gov/bulk/PET.zip',\n",
     "    #'http://api.eia.gov/bulk/NG.zip',\n",
     "    #'http://api.eia.gov/bulk/TOTAL.zip',\n",
     "    #'http://api.eia.gov/bulk/SEDS.zip',\n",


### PR DESCRIPTION
- Use https to make request
- Change request URL from `http://api.eia.gov/bulk/PET.zip` to `https://api.eia.gov/bulk/PET.zip`